### PR TITLE
Include option to ignore saving objects

### DIFF
--- a/src/ReplicatedStorage/EasyVisuals/init.lua
+++ b/src/ReplicatedStorage/EasyVisuals/init.lua
@@ -22,7 +22,7 @@ local function ValidateIsPreset(presetName: string): boolean
 	return Presets:FindFirstChild(presetName) ~= nil;
 end
 
-function Effect.new<T...>(uiInstance: GuiObject, effectType: string, speed: number?, size: number?): Effect<T...>
+function Effect.new<T...>(uiInstance: GuiObject, effectType: string, speed: number?, size: number?, ignoreSavingObjects: boolean?): Effect<T...>
 	assert(uiInstance, "UIInstance not provided");
 	assert(effectType, "EffectType not provided");
 	assert(uiInstance:IsA("GuiObject"), "UIInstance is not a GuiObject");
@@ -44,10 +44,12 @@ function Effect.new<T...>(uiInstance: GuiObject, effectType: string, speed: numb
 	self.Speed = speed or 0.007;
 	self.Size = size or 1;
 
-	for _, Object in uiInstance:GetChildren() do
-		if (Object:IsA("UIStroke") or Object:IsA("UIGradient")) then
-			table.insert(self.SavedObjects, Object);
-			Object.Parent = nil;
+	if not ignoreSavingObjects then
+		for _, Object in uiInstance:GetChildren() do
+			if (Object:IsA("UIStroke") or Object:IsA("UIGradient")) then
+				table.insert(self.SavedObjects, Object);
+				Object.Parent = nil;
+			end;
 		end;
 	end;
 

--- a/src/ReplicatedStorage/EasyVisuals/init.lua
+++ b/src/ReplicatedStorage/EasyVisuals/init.lua
@@ -44,7 +44,7 @@ function Effect.new<T...>(uiInstance: GuiObject, effectType: string, speed: numb
 	self.Speed = speed or 0.007;
 	self.Size = size or 1;
 
-	if not ignoreSavingObjects then
+	if (not ignoreSavingObjects) then
 		for _, Object in uiInstance:GetChildren() do
 			if (Object:IsA("UIStroke") or Object:IsA("UIGradient")) then
 				table.insert(self.SavedObjects, Object);


### PR DESCRIPTION
In some cases you may want to stack effects or apply an effect to a `GuiObject` with `UIStrokes` and `UIGradients` already applied to it. This optional `ignoreSavingObjects` parameter grants the ability to do so.